### PR TITLE
adds emojifier and implements throughout blog

### DIFF
--- a/src/components/AllPosts.js
+++ b/src/components/AllPosts.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import sanityClient from "../client.js";
 import { Timestamp } from "./Timestamper.js";
+import Emojify from "./CategoryEmojifier.js";
 import BlockContent from "@sanity/block-content-to-react";
 import {
   Jumbotron,
@@ -34,6 +35,9 @@ export default function AllPosts() {
               _id,
               url
             }
+          },
+          categories[0] -> {
+            title
           },
         body,
         publishedAt
@@ -77,7 +81,8 @@ export default function AllPosts() {
                 <Row>
                   <Col>
                     <CardTitle tag="h5" key={index}>
-                      {post.title} 📄
+                      {Emojify(post.categories)}
+                      {post.title}
                     </CardTitle>
                   </Col>
                   <Col>

--- a/src/components/Archive.js
+++ b/src/components/Archive.js
@@ -13,7 +13,7 @@ export default function Archive() {
         `*[_type == "post"]{
           title,
           slug,
-          publishedAt
+          publishedAt,
         }`
       )
       .then(data => setAllPosts(data))

--- a/src/components/CategoryEmojifier.js
+++ b/src/components/CategoryEmojifier.js
@@ -1,0 +1,16 @@
+import { React, useState, useEffect } from "react";
+
+export const Emojify = category => {
+  if (category) {
+    let { title } = category;
+    if (title === "testcase") {
+      return "📝";
+    } else {
+      return "woops";
+    }
+  } else {
+    return "📄";
+  }
+};
+
+export default Emojify;

--- a/src/components/OnePost.js
+++ b/src/components/OnePost.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import sanityClient from "../client.js";
 import { Timestamp } from "./Timestamper.js";
+import Emojify from "./CategoryEmojifier.js";
 import BlockContent from "@sanity/block-content-to-react";
 import imageUrlBuilder from "@sanity/image-url";
 import { Container, Row, Col, Spinner } from "reactstrap";
@@ -27,6 +28,9 @@ export default function OnePost() {
               url
             }
           },
+          categories[0] -> {
+            title
+          },
         body,
         publishedAt
       }`,
@@ -48,7 +52,10 @@ export default function OnePost() {
       <Row>
         <Row>
           <Col>
-            <h2>{postData.title}</h2>
+            <h2>
+              {Emojify(postData.categories)}
+              {postData.title}
+            </h2>
           </Col>
         </Row>
         <Row>

--- a/src/components/archiveSort.js
+++ b/src/components/archiveSort.js
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { Table } from "reactstrap";
 import sanityClient from "../client.js";
 import { Timestamp } from "./Timestamper.js";
+import Emojify from "./CategoryEmojifier.js";
 
 export const ArchiveSort = () => {
   const [allPostsData, setAllPosts] = useState(null);
@@ -13,13 +14,15 @@ export const ArchiveSort = () => {
         `*[_type == "post"]{
           title,
           slug,
-          publishedAt
+          publishedAt,
+          categories[0] -> {
+            title
+          }
         }`
       )
       .then(data =>
         setAllPosts(
           data.sort(function(a, b) {
-            console.log(a.publishedAt);
             return Date.parse(b.publishedAt) - Date.parse(a.publishedAt);
           })
         )
@@ -35,7 +38,10 @@ export const ArchiveSort = () => {
             <tr>
               <td>
                 <Link to={"/" + post.slug.current} key={post.slug.current}>
-                  <span key={index}>📄 {post.title}</span>{" "}
+                  <span key={index}>
+                    {console.log(post)}
+                    {Emojify(post.categories)} {post.title}
+                  </span>{" "}
                 </Link>
               </td>
               <td className="text-muted" style={{ textAlign: "right" }}>


### PR DESCRIPTION
Adds `EmojifyCategory.js` which includes `Emojifier(category)` , makes changes to fetch requests to handle getting categories, and implements the function across blog pages.  `Emojifier(category)` takes a post's category and returns an emoji depending on the particular category. As of right now it only checks for a testcase category as a proof of concept, but extending the function is quite simple.

In the future, it might be worth considering if this is an unnecessary function and if category assignations in Sanity should just include emoji in some fashion.

Closes #3 